### PR TITLE
Relative file lookups are incorrectly shimmed

### DIFF
--- a/test/fixtures/node_modules/module-t/lib/index-browser.js
+++ b/test/fixtures/node_modules/module-t/lib/index-browser.js
@@ -1,0 +1,3 @@
+var realIndex = require('./index');
+
+module.exports = realIndex;

--- a/test/fixtures/node_modules/module-t/lib/index.js
+++ b/test/fixtures/node_modules/module-t/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/fixtures/node_modules/module-t/package.json
+++ b/test/fixtures/node_modules/module-t/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "module-t",
+    "main": "./lib/index",
+    "browser": "./lib/index-browser"
+}

--- a/test/modules.js
+++ b/test/modules.js
@@ -305,3 +305,16 @@ test('not fail on accessing path name defined in Object.prototype', function (do
         done();
     });
 });
+
+test('internal relative paths don\'t use browser alternates', function (done) {
+    var parent = {
+        filename: fixtures_dir + '/module-t/lib/index-browser.js'
+    };
+
+    resolve('./index', parent, function(err, path, pkg) {
+        assert.ifError(err);
+        assert.equal(path, require.resolve('./fixtures/node_modules/module-t/lib/index'));
+        done();
+    });
+    
+});


### PR DESCRIPTION
After version 0.11.0 was released a project that was packaged with browserify starting to build with the wrong contents.  I tracked the problem down to version 0.11.0 being used to package module ltx 0.9.1.  

I've created a testcase that demonstrates a change in file resolution between 0.10 and 0.11.  I didn't find an obvious solution to the problem, so I thought I'd start with a PR with the testcase and see if anybody else had thoughts. I'm happy to code the fix if there is an approach that somebody can explain.
