### PR TITLE
Ensure a default value is set for options.filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,8 +214,10 @@ function resolve(id, opts, cb) {
     // opts.packageFilter
 
     opts = opts || {};
-
-    var base = path.dirname(opts.filename);
+    
+    // NOTE: Starting with Node v6+ passing undefined to path.dirname results in a TypeError
+	// If opts.filename is undefined, use the filename that is being executed (e.g. node global: __filename)
+    var base = path.dirname(opts.filename || __filename);
 
     if (opts.basedir) {
         base = opts.basedir;


### PR DESCRIPTION
Starting with Node v6+, path.dirname will **not** accept undefined inputs.  Use the Node global variable `__filename` as a default value if `filename` is not passed in in the configuration object to node-browser-resolve-call.
